### PR TITLE
add encryptInDomain()

### DIFF
--- a/main.go
+++ b/main.go
@@ -242,8 +242,8 @@ func main() {
 	}
 
 	// if encrypting in a specific use domain, ensure the use domain value was set
-	isDomainFlagSet := isFlagPassed("domain")
-	if isDomainFlagSet && useDomain != nil && *useDomain == "" && shouldEncrypt != nil && *shouldEncrypt {
+	domainFlagIsSet := isFlagPassed("domain")
+	if domainFlagIsSet && useDomain != nil && *useDomain == "" && shouldEncrypt != nil && *shouldEncrypt {
 		log.Fatal("An attempt was made to use a specific use domain to encrypt, yet the use domain name was not provided in " +
 			"cli, consider -domain=DOMAIN_NAME")
 	}
@@ -297,7 +297,7 @@ func main() {
 		if config.Verbose {
 			log.Println("Encrypting")
 		}
-		if isDomainFlagSet && useDomain != nil && *useDomain != "" {
+		if domainFlagIsSet && useDomain != nil && *useDomain != "" {
 			if config.Verbose {
 				log.Println("A use domain has been set to: " + *useDomain)
 			}


### PR DESCRIPTION
Added a flag `-domain` to signal encryptInDomain()

- the value of the flag is validated only when `-encrypt` is specified; `-decrypt` does not care about a use domain
- please help testing locally

To build locally:
```
cd /peacemakr-cli
go mod vendor && go install && export ARTIFACT_PATH=`go env GOPATH`/bin/peacemakr-cli

# run it
echo "secret" | $ARTIFACT_PATH -encrypt
echo "secret" | $ARTIFACT_PATH -encrypt -domain=default
echo "secret" | $ARTIFACT_PATH -encrypt -domain=unknowndomain
```

Use can also enable verbose to get info message in the stdout:
```
2020/12/22 08:20:47 Finish parsing flag and config
2020/12/22 08:20:47 Input Filename: , Output Filename: 
2020/12/22 08:20:47 Setting up SDK...
2020/12/22 08:20:47 registering client
2020/12/22 08:20:47 Encrypting
2020/12/22 08:20:47 A use domain has been set to: default3
```