### PR TITLE
Upgrade go-sdk to v0.0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine
 RUN apk update && apk upgrade && apk add --no-cache ca-certificates && update-ca-certificates
 
 COPY --from=builder /go/src/github.com/peacemakr/peacemakr-cli/vendor/ /go/src/
-COPY --from=builder /go/pkg/mod/github.com/peacemakr-io/peacemakr-go-sdk@v0.0.11/pkg/crypto/lib/libpeacemakr-core-crypto.so /lib/
+COPY --from=builder /go/pkg/mod/github.com/peacemakr-io/peacemakr-go-sdk@v0.0.12/pkg/crypto/lib/libpeacemakr-core-crypto.so /lib/
 
 WORKDIR /go/bin/
 COPY --from=builder /go/bin/peacemakr-cli /go/bin/peacemakr-cli

--- a/Dockerfile-dependencies
+++ b/Dockerfile-dependencies
@@ -11,5 +11,5 @@ ADD main.go /go/src/github.com/peacemakr/peacemakr-cli/
 # but this should be fixed
 RUN cd src/github.com/peacemakr/peacemakr-cli/ && GO111MODULE=on go mod vendor
 # to pick up binaries from a specific commit: go get github.com/peacemakr-io/peacemakr-go-sdk@<commit>
-RUN cp -r /go/pkg/mod/github.com/peacemakr-io/peacemakr-go-sdk@v0.0.11/pkg/crypto/include /go/src/github.com/peacemakr/peacemakr-cli/vendor/github.com/peacemakr-io/peacemakr-go-sdk/pkg/crypto/
-RUN cp -r /go/pkg/mod/github.com/peacemakr-io/peacemakr-go-sdk@v0.0.11/pkg/crypto/lib /go/src/github.com/peacemakr/peacemakr-cli/vendor/github.com/peacemakr-io/peacemakr-go-sdk/pkg/crypto/
+RUN cp -r /go/pkg/mod/github.com/peacemakr-io/peacemakr-go-sdk@v0.0.12/pkg/crypto/include /go/src/github.com/peacemakr/peacemakr-cli/vendor/github.com/peacemakr-io/peacemakr-go-sdk/pkg/crypto/
+RUN cp -r /go/pkg/mod/github.com/peacemakr-io/peacemakr-go-sdk@v0.0.12/pkg/crypto/lib /go/src/github.com/peacemakr/peacemakr-cli/vendor/github.com/peacemakr-io/peacemakr-go-sdk/pkg/crypto/

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.12
 require (
 	github.com/kennygrant/sanitize v1.2.4
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/peacemakr-io/peacemakr-go-sdk v0.0.11
+	github.com/peacemakr-io/peacemakr-go-sdk v0.0.12
 	github.com/spf13/viper v1.7.1
 )

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTK
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/peacemakr-io/peacemakr-go-sdk v0.0.11 h1:6Zfwax90cKy4rY+ujS7wOitDRov3EmFhKAe/aKKuIBM=
 github.com/peacemakr-io/peacemakr-go-sdk v0.0.11/go.mod h1:IqKgW4oGSz/fFqmBOeeSI+uLLD2IR1piMPV+Uzrm29I=
+github.com/peacemakr-io/peacemakr-go-sdk v0.0.12 h1:+2F31+jwFuS60bt3B6U1EAb9w06kty3qA+r1eZp1II0=
+github.com/peacemakr-io/peacemakr-go-sdk v0.0.12/go.mod h1:IqKgW4oGSz/fFqmBOeeSI+uLLD2IR1piMPV+Uzrm29I=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Changes
- EncryptInDomain() will fail and return error message if the selected use-domain is not viable for encryption